### PR TITLE
Fix error: unknown type name ‘Window’

### DIFF
--- a/qemu/include/ui/egl-helpers.h
+++ b/qemu/include/ui/egl-helpers.h
@@ -43,7 +43,7 @@ void egl_dmabuf_release_texture(QemuDmaBuf *dmabuf);
 
 #endif
 
-EGLSurface qemu_egl_init_surface_x11(EGLContext ectx, Window win);
+EGLSurface qemu_egl_init_surface_x11(EGLContext ectx, EGLNativeWindowType win);
 
 int qemu_egl_init_dpy_x11(EGLNativeDisplayType dpy, DisplayGLMode mode);
 int qemu_egl_init_dpy_mesa(EGLNativeDisplayType dpy, DisplayGLMode mode);

--- a/qemu/ui/egl-helpers.c
+++ b/qemu/ui/egl-helpers.c
@@ -273,7 +273,7 @@ void egl_dmabuf_release_texture(QemuDmaBuf *dmabuf)
 
 /* ---------------------------------------------------------------------- */
 
-EGLSurface qemu_egl_init_surface_x11(EGLContext ectx, Window win)
+EGLSurface qemu_egl_init_surface_x11(EGLContext ectx, EGLNativeWindowType win)
 {
     EGLSurface esurface;
     EGLBoolean b;

--- a/qemu/ui/gtk-egl.c
+++ b/qemu/ui/gtk-egl.c
@@ -54,7 +54,7 @@ void gd_egl_init(VirtualConsole *vc)
     }
 
     vc->gfx.ectx = qemu_egl_init_ctx();
-    vc->gfx.esurface = qemu_egl_init_surface_x11(vc->gfx.ectx, x11_window);
+    vc->gfx.esurface = qemu_egl_init_surface_x11(vc->gfx.ectx, (EGLNativeWindowType)x11_window);
 
     assert(vc->gfx.esurface);
 }


### PR DESCRIPTION
Cherrypicking a commit(fbd57c754f32) from the original qemu:

> Subject: egl-helpers.h: do not depend on X11 Window type, use EGLNativeWindowType
> 
> It was assumed that mesa provides the necessary X11 includes,
> but it is not always the case, as it can be configured without x11 support.
>
> Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
> Reviewed-by: Philippe Mathieu-Daudé <philmd@redhat.com>
> Message-id: 20190116113751.17177-1-alex.kanavin@gmail.com
>
> [ kraxel: codestyle fix (long line) ]
>
> Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>

See https://github.com/qemu/qemu/commit/fbd57c754f32804a63295f70f271d1ef128ee590

Fix #20 